### PR TITLE
Add non-launchable user installed apps in Split tunneling list

### DIFF
--- a/core/src/main/java/net/ivpn/core/v2/viewmodel/SplitTunnelingViewModel.java
+++ b/core/src/main/java/net/ivpn/core/v2/viewmodel/SplitTunnelingViewModel.java
@@ -147,7 +147,10 @@ public class SplitTunnelingViewModel {
             List<ApplicationItem> items = new LinkedList<>();
             for (ApplicationInfo info : applicationInfoList) {
                 try {
-                    if (null != packageManager.getLaunchIntentForPackage(info.packageName)) {
+                    if (null != packageManager.getLaunchIntentForPackage(info.packageName) ||
+                            null != packageManager.getLeanbackLaunchIntentForPackage(info.packageName) ||
+                            null != packageManager.getInstallerPackageName(info.packageName)
+                    ) {
                         items.add(new ApplicationItem(info.loadLabel(packageManager).toString(), info.packageName,
                                 info.loadIcon(packageManager)));
                     }

--- a/core/src/main/java/net/ivpn/core/v2/viewmodel/SplitTunnelingViewModel.java
+++ b/core/src/main/java/net/ivpn/core/v2/viewmodel/SplitTunnelingViewModel.java
@@ -145,14 +145,17 @@ public class SplitTunnelingViewModel {
         @Override
         protected List<ApplicationItem> doInBackground(Void... voids) {
             List<ApplicationItem> items = new LinkedList<>();
+            Set<String> packageNames = new HashSet<>();
             for (ApplicationInfo info : applicationInfoList) {
                 try {
                     if (null != packageManager.getLaunchIntentForPackage(info.packageName) ||
                             null != packageManager.getLeanbackLaunchIntentForPackage(info.packageName) ||
                             null != packageManager.getInstallerPackageName(info.packageName)
                     ) {
-                        items.add(new ApplicationItem(info.loadLabel(packageManager).toString(), info.packageName,
-                                info.loadIcon(packageManager)));
+                        if (packageNames.add(info.loadLabel(packageManager).toString())) {
+                            items.add(new ApplicationItem(info.loadLabel(packageManager).toString(), info.packageName,
+                                    info.loadIcon(packageManager)));
+                        }
                     }
                 } catch (Exception e) {
                     e.printStackTrace();


### PR DESCRIPTION
Include non-launchable user installed apps in the Split tunnel list

## PR type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes

Resolves #285
