### PR TITLE
Bug Fix : Wireguard ipv6 not working

### DIFF
--- a/core/src/main/java/com/wireguard/android/backend/GoBackend.java
+++ b/core/src/main/java/com/wireguard/android/backend/GoBackend.java
@@ -255,7 +255,14 @@ public final class GoBackend implements Backend {
 
             if (encryptedSettingsPreference.getObfuscationType() != ObfuscationType.DISABLED) {
                 try {
-                    service.updateV2raySettingsInService();
+                    String selectedPeerPublicKey = null;
+                    if (config != null && config.getPeers() != null) {
+                        for (final Peer peer : config.getPeers()) {
+                            selectedPeerPublicKey = peer.getPublicKey();
+                            break;
+                        }
+                    }
+                    service.updateV2raySettingsInService(selectedPeerPublicKey);
                 } catch (final Exception e) {
                     LOGGER.error("Failed to update V2Ray settings in service", e);
                 }
@@ -439,7 +446,7 @@ public final class GoBackend implements Backend {
             return super.onStartCommand(intent, flags, startId);
         }
 
-        public void updateV2raySettingsInService() {
+        public void updateV2raySettingsInService(@Nullable final String selectedPeerPublicKey) {
             final ObfuscationType obfuscationType = encryptedSettingsPreference.getObfuscationType();
             serversRepository.loadV2raySettings();
             if (obfuscationType == ObfuscationType.DISABLED) {
@@ -469,7 +476,18 @@ public final class GoBackend implements Backend {
                 return;
             }
 
-            Host entryHost = selectHostWithV2ray(entryServer.getHosts());
+            Host entryHost = null;
+            if (selectedPeerPublicKey != null) {
+                for (Host h : entryServer.getHosts()) {
+                    if (h != null && selectedPeerPublicKey.equals(h.getPublicKey())) {
+                        entryHost = h;
+                        break;
+                    }
+                }
+            }
+            if (entryHost == null) {
+                entryHost = selectHostWithV2ray(entryServer.getHosts());
+            }
             if (entryHost == null) {
                 LOGGER.error("Entry server has no host with V2Ray configured, attempting offline refresh (service)");
                 try {
@@ -517,7 +535,18 @@ public final class GoBackend implements Backend {
             if (multiHopController.isReadyToUse()) {
                 Server exitServer = serversRepository.getCurrentServer(ServerType.EXIT);
                 if (exitServer != null && !exitServer.getHosts().isEmpty()) {
-                    Host exitHost = exitServer.getHosts().get(0);
+                    Host exitHost = null;
+                    if (selectedPeerPublicKey != null) {
+                        for (Host h : exitServer.getHosts()) {
+                            if (h != null && selectedPeerPublicKey.equals(h.getPublicKey())) {
+                                exitHost = h;
+                                break;
+                            }
+                        }
+                    }
+                    if (exitHost == null) {
+                        exitHost = exitServer.getHosts().get(0);
+                    }
                     v2rayInboundIp = exitHost.getHost() != null ? exitHost.getHost() : "";
                     v2rayInboundPort = settings.getWireGuardPort().getPortNumber();
                     LOGGER.info("Multi-hop V2Ray inbound set to ExitServer WG endpoint (service): " + exitHost.getHost() + ":" + v2rayInboundPort);

--- a/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
+++ b/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
@@ -136,10 +136,6 @@ class ConfigManager @Inject constructor(
     }
 
 
-
-
-
-
     private fun generateConfig(server: Server?, port: Port): Config? {
         LOGGER.info("Generating WireGuard configuration for single-hop connection")
 
@@ -154,7 +150,7 @@ class ConfigManager @Inject constructor(
             return null
         }
 
-        val host = server.hosts[0]
+        val host = server.hosts.random()
         LOGGER.info("Using server host: ${host.hostname} (${host.host})")
 
         return createWireGuardConfig(
@@ -185,8 +181,8 @@ class ConfigManager @Inject constructor(
             return null
         }
 
-        val entryHost = entryServer.hosts[0]
-        val exitHost = exitServer.hosts[0]
+        val entryHost = entryServer.hosts.random()
+        val exitHost = exitServer.hosts.random()
 
         LOGGER.info("Multi-hop: Entry server: ${entryHost.hostname} (${entryHost.host})")
         LOGGER.info("Multi-hop: Exit server: ${exitHost.hostname} (${exitHost.host})")

--- a/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
+++ b/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
@@ -150,8 +150,17 @@ class ConfigManager @Inject constructor(
             return null
         }
 
-        val host = server.hosts.random()
-        LOGGER.info("Using server host: ${host.hostname} (${host.host})")
+        val host = if (v2rayController.isV2RayEnabled()) {
+            val candidates = server.hosts.filter { it.v2ray != null && it.v2ray.isNotEmpty() }
+            val selected = candidates.randomOrNull() ?: server.hosts.random()
+            if (candidates.isEmpty()) {
+                LOGGER.warn("No hosts with V2Ray available; falling back to any host")
+            }
+            selected
+        } else {
+            server.hosts.random()
+        }
+        LOGGER.info("Using server host: ${host.hostname} (${host.host})" )
 
         return createWireGuardConfig(
             peerHost = host,
@@ -181,7 +190,16 @@ class ConfigManager @Inject constructor(
             return null
         }
 
-        val entryHost = entryServer.hosts.random()
+        val entryHost = if (v2rayController.isV2RayEnabled()) {
+            val candidates = entryServer.hosts.filter { it.v2ray != null && it.v2ray.isNotEmpty() }
+            val selected = candidates.randomOrNull() ?: entryServer.hosts.random()
+            if (candidates.isEmpty()) {
+                LOGGER.warn("No entry hosts with V2Ray available; falling back to any entry host")
+            }
+            selected
+        } else {
+            entryServer.hosts.random()
+        }
         val exitHost = exitServer.hosts.random()
 
         LOGGER.info("Multi-hop: Entry server: ${entryHost.hostname} (${entryHost.host})")

--- a/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
+++ b/core/src/main/java/net/ivpn/core/vpn/wireguard/ConfigManager.kt
@@ -260,7 +260,7 @@ class ConfigManager @Inject constructor(
         val peer = Peer().also {
             // uses same AllowedIPs for both single-hop and multi-hop to disable wg's internal firewall
             // Android VPN service handles routing, so we need to disable WireGuard's firewall
-            it.setAllowedIPsString("128.0.0.0/1, 0.0.0.0/1")
+            it.setAllowedIPsString("0.0.0.0/0, ::/0")
             it.setEndpointString(endpoint)
             it.publicKey = peerHost.publicKey
         }
@@ -297,8 +297,12 @@ class ConfigManager @Inject constructor(
 
         val entryHost = hosts[0]
         val localIPv6AddressForEntry = entryHost.ipv6.local_ip
-        config.getInterface()
-            .setAddressString("$ipAddress,${localIPv6AddressForEntry}")
+        val ipv4OnlyAddress = ipAddress?.split("/")?.get(0) ?: ipAddress
+        val ipv6Prefix = localIPv6AddressForEntry?.split("/")?.get(0) ?: ""
+        val combinedAddresses = "$ipAddress/32,${ipv6Prefix}${ipv4OnlyAddress}/128"
+        
+        LOGGER.info("Setting IPv6 addresses: $combinedAddresses")
+        config.getInterface().setAddressString(combinedAddresses)
     }
 
     private fun getDNS(host: Host): String {


### PR DESCRIPTION
## PR type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] I have read the CONTRIBUTING.md doc
- [x] I have added necessary documentation (if appropriate)
- [x] The Git workflow follows our guidelines: CONTRIBUTING.md#git

## What is the current behavior?

When IPv6 is enabled for WireGuard, no IPv6 address is detected. Connecting to servers that support IPv6 fails to provide an IPv6 address.
This appears to be a regression, as the issue does not occur in previous builds.

Issue number: #398

## What is the new behavior?
When IPv6 is enabled, the client should receive and display an assigned IPv6 address from the connected server.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact it has for existing app version. -->

## Other information
